### PR TITLE
Remove sort param from post body in getRequestOptions

### DIFF
--- a/Historical Volume Charts/Util.js
+++ b/Historical Volume Charts/Util.js
@@ -22,8 +22,7 @@ function getRequestOptions(asins) {
           include_variants: true,
           min_word_count: 1,
           max_word_count: 10,
-          min_organic_product_count: 1,
-          sort: '-monthly_search_volume_exact',
+          min_organic_product_count: 1
         },
       },
     }),

--- a/Organic Impressions Estimator/RankingDataFetcher.js
+++ b/Organic Impressions Estimator/RankingDataFetcher.js
@@ -20,8 +20,7 @@ function getAllRankingData(url, options, primaryAsin, competitorAsins, rankedKey
         include_variants: true,
         min_word_count: 1,
         max_word_count: 10,
-        min_organic_product_count: 1,
-        sort: '-monthly_search_volume_exact',
+        min_organic_product_count: 1
       },
     },
   });

--- a/Organic Impressions Estimator/Util.js
+++ b/Organic Impressions Estimator/Util.js
@@ -22,8 +22,7 @@ function getRequestOptions(asins) {
           include_variants: true,
           min_word_count: 1,
           max_word_count: 10,
-          min_organic_product_count: 1,
-          sort: '-monthly_search_volume_exact',
+          min_organic_product_count: 1
         },
       },
     }),


### PR DESCRIPTION
## Description

Related to support request [here](https://junglescout.slack.com/archives/C06LELG5JAE/p1714501168999629)

Customer was getting a 400 Bad Request with error message: “unpermitted sort parameter” because the sort param was being set in the post request body (as well as the query params) --> it should only be included in the query params. 

## QA

1. Follow instructions in the Readme to copy [this sheet](https://docs.google.com/spreadsheets/d/1BQZPbFI2K2kI6sAEvi3sm04Tfsdl_3YCrPAinZ7SDyY/edit) and upload the Organic Impression Estimator .gs files from this branch to Google App script
2. OR, if you already have it loaded up, just delete the line from this PR
3. Then run "fetchKeywords" and it should run successfully with no errors, and populate keywords in the ASINs tab

<img width="812" alt="Screenshot 2024-04-30 at 5 47 12 PM" src="https://github.com/Junglescout/junglescout-google-apps-scripts/assets/44414413/a04b6038-c44a-4e74-8250-526279e4f7ad">
<img width="960" alt="Screenshot 2024-04-30 at 5 47 28 PM" src="https://github.com/Junglescout/junglescout-google-apps-scripts/assets/44414413/739c569d-3e4e-40af-aa4b-dad6477309d6">
