### PR TITLE
Fix bugs in rank fetcher and add runAllSheets function

### DIFF
--- a/Organic Impressions Estimator/Code.js
+++ b/Organic Impressions Estimator/Code.js
@@ -11,6 +11,25 @@ const AUTHORIZATION_TOKEN = `${API_KEY_NAME}:${API_KEY}`; // Build proper token 
  */
 const TARGET_SPREADSHEET_ID = scriptProperties.getProperty('TARGET_SPREADSHEET_ID');
 
+function runAllSheets() {
+  const ss = SpreadsheetApp.openById(TARGET_SPREADSHEET_ID);
+  const sheet = ss.getSheetByName('ASINs');
+  if (!sheet) return;
+
+  const response = Browser.msgBox('Warning', 'Running this action will use multiple API calls to populate all of the data in each sheet. Consider testing each individual action first using the boxes to the right before you continue. Do you wish to proceed?', Browser.Buttons.OK_CANCEL);
+
+  if (response === 'cancel') {
+    Logger.log('Run all sheets aborted by the user.');
+    return;
+  }
+
+  fetchKeywords()
+  getRanksAndPopulateRankByDay()
+  fetchHistoricalSearchVolumesV2()
+  calculateOrganicImpressions()
+  populateImpressionsChart()
+}
+
 /**
  * Fetches keywords from the Jungle Scout API and updates the spreadsheet.
  */
@@ -54,6 +73,17 @@ function fetchKeywords() {
 
   getAllKeywords(initialUrl, options, sheet, maxKeywords, rankedKeywordsOnly);
 }
+
+/**
+ * Fetches keywords and ranks for ASINs, updates the spreadsheet, then
+ * collects all the data from the "Raw Rank Data" sheet and populates the "Rank by Day" sheet.
+ */
+
+function getRanksAndPopulateRankByDay() {
+  fetchRankingData()
+  populateRankByDaySheet()
+}
+
 
 /**
  * Fetches keywords and ranks for ASINs and updates the spreadsheet.

--- a/Organic Impressions Estimator/RankingDataFetcher.js
+++ b/Organic Impressions Estimator/RankingDataFetcher.js
@@ -88,10 +88,10 @@ function getAllRankingData(url, options, primaryAsin, competitorAsins, rankedKey
     if (!formattedMostRecentDate || formattedUpdatedAt > formattedMostRecentDate) {
       // Check if formattedUpdatedAt is within the last 90 days
       const today = new Date();
-      const sevenDaysAgo = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
+      const ninetyDaysAgo = new Date(today.getTime() - 90 * 24 * 60 * 60 * 1000);
       const updatedAtDate = new Date(formattedUpdatedAt);
       
-      if (updatedAtDate >= sevenDaysAgo) {
+      if (updatedAtDate >= ninetyDaysAgo) {
         const rowData = [
           primaryAsin,
           keyword,

--- a/Organic Impressions Estimator/RankingDataFetcher.js
+++ b/Organic Impressions Estimator/RankingDataFetcher.js
@@ -86,12 +86,13 @@ function getAllRankingData(url, options, primaryAsin, competitorAsins, rankedKey
 
     // Compare formatted date strings
     if (!formattedMostRecentDate || formattedUpdatedAt > formattedMostRecentDate) {
-      // Check if formattedUpdatedAt is within the last 90 days
+      // Check if formattedUpdatedAt is within the last 7 days
       const today = new Date();
-      const ninetyDaysAgo = new Date(today.getTime() - 90 * 24 * 60 * 60 * 1000);
+      const sevenDaysAgo = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
       const updatedAtDate = new Date(formattedUpdatedAt);
       
-      if (updatedAtDate >= ninetyDaysAgo) {
+      // Only save data for keyword ranks updated within the last 7 days
+      if (updatedAtDate >= sevenDaysAgo) {
         const rowData = [
           primaryAsin,
           keyword,
@@ -117,7 +118,7 @@ function getAllRankingData(url, options, primaryAsin, competitorAsins, rankedKey
         Logger.log(`newRankingData: ${newRankingData}`);
         Logger.log(`Saved data for ASIN: ${primaryAsin}, Keyword: ${keyword}, Organic Rank: ${organicRank}, Sponsored Rank: ${sponsoredRank}`);
       } else {
-        Logger.log(`Skipped keyword "${keyword}" with formattedUpdatedAt: ${formattedUpdatedAt} (not within the last 90 days)`);
+        Logger.log(`Skipped keyword "${keyword}" with formattedUpdatedAt: ${formattedUpdatedAt} (not within the last 7 days)`);
       }
     }
   }


### PR DESCRIPTION
## Description

This PR makes a small adjustment to the RankingDataFetcher to use keywords that have been updated in the last 90 days instead of just the last 7 days, to be consistent with the comments (looks like `sevenDaysAgo` might have just been leftover from an experiment). 

It also adds a new action `runAllSheets` to easily circulate through the five big actions to populate all data in each sheet. This includes a warning to the user in case they haven't tested the sheets separately, and to let them know that it'll eat up API calls all at once. This action can be run just from the script file, or potentially added to a new button on the ASINs sheet if you needed to call it easily from there. 