### PR TITLE
Create spreadsheet tabs if they don't exist

### DIFF
--- a/Organic Impressions Estimator/Code.js
+++ b/Organic Impressions Estimator/Code.js
@@ -99,8 +99,18 @@ function fetchHistoricalSearchVolumesV2() {
   // Prepare the target sheet for keyword volume
   let keywordVolumeSheet = ss.getSheetByName('Keyword Volume');
   if (!keywordVolumeSheet) {
-    keywordVolumeSheet = ss.insertSheet('Keyword Volume', 1);
+    const numSheets = ss.getNumSheets();
+    keywordVolumeSheet = ss.insertSheet('Keyword Volume', numSheets - 2);
     Logger.log(`Keyword Volume sheet created.`);
+    
+    // Freeze the first column
+    keywordVolumeSheet.setFrozenColumns(1);
+
+    // Freeze the first two rows
+    keywordVolumeSheet.setFrozenRows(2);
+    
+    // Set the background color of the first two rows to '#EFEFEF'
+    keywordVolumeSheet.getRange(1, 1, 2, keywordVolumeSheet.getMaxColumns()).setBackground('#EFEFEF');
   }
 
   // Initialize weeks to add as 0

--- a/Organic Impressions Estimator/Code.js
+++ b/Organic Impressions Estimator/Code.js
@@ -80,65 +80,6 @@ function fetchRankingData() {
 }
 
 /**
- * Collects all the data from the "Raw Rank Data" sheet and populates the "Rank by Day" sheet.
- */
-function populateRankByDaySheet() {
-  const ss = SpreadsheetApp.openById(TARGET_SPREADSHEET_ID);
-  const rankingSheet = ss.getSheetByName('Raw Rank Data');
-  const rankingData = rankingSheet.getDataRange().getValues();
-
-  // Remove header row from rankingData
-  rankingData.shift();
-
-  // Create newRankingData array with required columns, skipping rows with null organic_rank
-  const newRankingData = rankingData
-    .filter(row => row[3] !== '')
-    .map(row => {
-      const date = new Date(row[2]);
-      const formattedDate = date.toISOString().split('T')[0];
-      return [row[0], row[1], formattedDate, row[3]];
-    });
-
-  Logger.log(`newRankingData: ${JSON.stringify(newRankingData)}`);
-
-  // Sort newRankingData by ascending date
-  newRankingData.sort((a, b) => new Date(a[2]) - new Date(b[2]));
-
-  Logger.log(`Sorted newRankingData: ${JSON.stringify(newRankingData)}`);
-
-  // Group newRankingData by keyword
-  const groupedData = newRankingData.reduce((acc, row) => {
-    const keyword = row[1];
-    if (!acc[keyword]) {
-      acc[keyword] = [];
-    }
-    acc[keyword].push(row);
-    return acc;
-  }, {});
-
-  Logger.log(`Grouped data: ${JSON.stringify(groupedData)}`);
-
-  // Create an array to store the updated ranking data
-  const updatedRankingData = [];
-
-  // Iterate over each group of keyword data
-  Object.entries(groupedData).forEach(([keyword, keywordData]) => {
-    Logger.log(`Processing keyword: ${keyword}`);
-    Logger.log(`Keyword data: ${JSON.stringify(keywordData)}`);
-
-    // Add all rows for each keyword to the updated ranking data
-    keywordData.forEach(row => {
-      updatedRankingData.push(row);
-    });
-  });
-
-  Logger.log(`Updated ranking data: ${JSON.stringify(updatedRankingData)}`);
-
-  // Call updateRankByDaySheet with the updated ranking data
-  updateRankByDaySheet(updatedRankingData);
-}
-
-/**
  * Fetches historical search volumes for keywords and updates the spreadsheet.
  */
 function fetchHistoricalSearchVolumesV2() {
@@ -258,7 +199,6 @@ function fetchHistoricalSearchVolumesV2() {
 
   Logger.log(`This is the end.`)
 }
-
 
 /**
  * Calculates and populates the 'Organic Impressions' sheet with estimated organic impressions based on keyword ranks and search volumes.

--- a/Organic Impressions Estimator/Code.js
+++ b/Organic Impressions Estimator/Code.js
@@ -220,10 +220,21 @@ function calculateOrganicImpressions() {
   const rankByDaySheet = ss.getSheetByName('Rank by Day');
   const keywordVolumeSheet = ss.getSheetByName('Keyword Volume');
 
+  // Prepare the target sheet for organic impressions
   let organicImpressionsSheet = ss.getSheetByName('Organic Impressions');
   if (!organicImpressionsSheet) {
-    organicImpressionsSheet = ss.insertSheet('Organic Impressions', ss.getSheets().length);
+    const numSheets = ss.getNumSheets();
+    organicImpressionsSheet = ss.insertSheet('Organic Impressions', numSheets - 3);
     Logger.log(`Organic Impressions sheet created.`);
+    
+    // Freeze the first column
+    organicImpressionsSheet.setFrozenColumns(1);
+
+    // Freeze the first row
+    organicImpressionsSheet.setFrozenRows(1);
+    
+    // Set the background color of the first row to '#EFEFEF'
+    organicImpressionsSheet.getRange(1, 1, 1, organicImpressionsSheet.getMaxColumns()).setBackground('#EFEFEF');
   }
 
   // Clear existing data in 'Organic Impressions'
@@ -255,8 +266,13 @@ function calculateOrganicImpressions() {
   const keywordsRange = organicImpressionsSheet.getRange(2, 1, data.keywords.length, 1);
   keywordsRange.setValues(data.keywords.map(keyword => [keyword]));
 
-  // Call the function to calculate and populate the Organic Impressions sheet
-  calculateAndPopulateOrganicImpressions(data, organicImpressionsSheet, filteredDates);
+  // Check if there are any matching dates
+  if (filteredDates.length === 0) {
+    SpreadsheetApp.getUi().alert("There are no dates for keyword volumes and ranks that overlap.");
+  } else {
+    // Call the function to calculate and populate the Organic Impressions sheet
+    calculateAndPopulateOrganicImpressions(data, organicImpressionsSheet, filteredDates);
+  }
 
   // Format the rest of the Keyword Volumn sheet
   setColumnWidths(organicImpressionsSheet);
@@ -266,7 +282,7 @@ function calculateOrganicImpressions() {
   Logger.log(`dataRange: ${dataRange}`)
   dataRange.setNumberFormat('#,##0');
 
-  // Format the headers
+  // Format the date headers
   organicImpressionsSheet.getRange(1, 1, 1, lastColumn)
         .setFontWeight('bold')
         .setBackground('#EFEFEF');

--- a/Organic Impressions Estimator/Code.js
+++ b/Organic Impressions Estimator/Code.js
@@ -292,6 +292,16 @@ function populateImpressionsChart() {
   const ss = SpreadsheetApp.openById(TARGET_SPREADSHEET_ID);
   const sourceSheet = ss.getSheetByName('Organic Impressions');
 
+  // Check if there is impression data starting in column B
+  const impressionDataRange = sourceSheet.getRange(2, 2, sourceSheet.getLastRow() - 1, 1);
+  const impressionData = impressionDataRange.getValues();
+  const hasImpressionData = impressionData.some(row => row[0] !== "");
+
+  if (!hasImpressionData) {
+    SpreadsheetApp.getUi().alert("There is no impression data to display.");
+    return;
+  }
+
   // Create the charts tab if it doesn't exist & clear if it does
   createChartTab();
   const chartSheet = ss.getSheetByName("Charts");

--- a/Organic Impressions Estimator/Code.js
+++ b/Organic Impressions Estimator/Code.js
@@ -309,7 +309,7 @@ function populateImpressionsChart() {
   dataRange.setNumberFormat('#,##0');
 
   // Format column widths
-  chartSheet.setColumnWidths(2,lastRow, 175);
+  chartSheet.setColumnWidths(2,lastColumn, 175);
 
   // Format the headers
   chartSheet.getRange(1, 1, 1, lastColumn)

--- a/Organic Impressions Estimator/HistoricalVolumeFetcherv2.js
+++ b/Organic Impressions Estimator/HistoricalVolumeFetcherv2.js
@@ -39,8 +39,16 @@ function getHistoricalDataForKeyword(keyword, marketplace, startDate, endDate) {
  * @param {GoogleAppsScript.Spreadsheet.Sheet} keywordVolumeSheet - The Google Sheet to check for existing keywords.
  */
 function separateKeywords(rankByDayKeywords, keywordVolumeSheet) {
-  const existingKeywordsRange = keywordVolumeSheet.getRange("A3:A" + keywordVolumeSheet.getLastRow());
+  const lastRow = keywordVolumeSheet.getLastRow();
+
+  if (lastRow < 3) {
+    // If the sheet has less than 3 rows (header rows), assume all keywords are new
+    return [rankByDayKeywords, []];
+  }
+
+  const existingKeywordsRange = keywordVolumeSheet.getRange("A3:A" + lastRow);
   const existingKeywords = existingKeywordsRange.getValues().flat().filter(String);
+
   const newKeywords = rankByDayKeywords.filter(keyword => !existingKeywords.includes(keyword));
   const existingKeywordsToUpdate = rankByDayKeywords.filter(keyword => existingKeywords.includes(keyword));
 

--- a/Organic Impressions Estimator/ImpressionsChartCreation.js
+++ b/Organic Impressions Estimator/ImpressionsChartCreation.js
@@ -4,7 +4,8 @@ function createChartTab() {
 
   // If sheet does not exist create it
   if (!chartSheet) {
-    chartSheet = ss.insertSheet("Charts", 1);
+    const numSheets = ss.getNumSheets();
+    chartSheet = ss.insertSheet("Charts", numSheets - 4);
     Logger.log(`Charts sheet created.`)
   } else {
     chartSheet.clear(); // Clear existing content

--- a/Organic Impressions Estimator/RankingDataFetcher.js
+++ b/Organic Impressions Estimator/RankingDataFetcher.js
@@ -210,15 +210,22 @@ function updateRankingSheet(newRankingData, competitorAsins) {
  */
 function updateRankByDaySheet(newRankingData) {
   const ss = SpreadsheetApp.openById(TARGET_SPREADSHEET_ID);
-  const rankByDaySheet = ss.getSheetByName('Rank by Day');
+  let rankByDaySheet = ss.getSheetByName('Rank by Day');
+
+  // Create the 'Rank by Day' sheet if it doesn't exist
+  if (!rankByDaySheet) {
+    const numSheets = ss.getNumSheets();
+    rankByDaySheet = ss.insertSheet('Rank by Day', numSheets - 1);
+  }
 
   // Get the existing data and headers from the "Rank by Day" sheet
   const existingData = rankByDaySheet.getDataRange().getValues();
   let existingHeaders = existingData[0];
 
   // If the sheet is empty, create a new header row with "Keyword" as the first column
-  if (existingHeaders.length === 0) {
+  if (existingHeaders.length === 0 || existingHeaders[0] !== "Keyword") {
     existingHeaders = ["Keyword"];
+    rankByDaySheet.getRange(1, 1, 1, 1).setValue("Keyword");
   }
 
   // Format existing header dates to 'YYYY-MM-DD' format
@@ -248,8 +255,12 @@ function updateRankByDaySheet(newRankingData) {
 
   // Update the headers in the sheet if new columns were added
   if (existingHeaders.length > rankByDaySheet.getLastColumn()) {
-    rankByDaySheet.getRange(1, 1, 1, existingHeaders.length).setValues([existingHeaders]).setFontWeight('bold');
+    rankByDaySheet.getRange(1, 1, 1, existingHeaders.length).setValues([existingHeaders]).setFontWeight('bold').setBackground('#EFEFEF');
   }
+
+  // Freeze the first column and first row
+  rankByDaySheet.setFrozenRows(1);
+  rankByDaySheet.setFrozenColumns(1);
 
   // Create a map of existing keywords and their row numbers
   const keywordMap = new Map();

--- a/Organic Impressions Estimator/RankingDataFetcher.js
+++ b/Organic Impressions Estimator/RankingDataFetcher.js
@@ -217,6 +217,7 @@ function updateRankByDaySheet(newRankingData) {
   if (!rankByDaySheet) {
     const numSheets = ss.getNumSheets();
     rankByDaySheet = ss.insertSheet('Rank by Day', numSheets - 1);
+    populateRankByDaySheet();
   }
 
   // Get the existing data and headers from the "Rank by Day" sheet

--- a/Organic Impressions Estimator/RankingDataFetcher.js
+++ b/Organic Impressions Estimator/RankingDataFetcher.js
@@ -35,7 +35,29 @@ function getAllRankingData(url, options, primaryAsin, competitorAsins, rankedKey
   Logger.log(`Received ${jsonResponse.data.length} keywords`);
 
   const ss = SpreadsheetApp.openById(TARGET_SPREADSHEET_ID);
-  const rankingSheet = ss.getSheetByName('Raw Rank Data');
+  let rankingSheet = ss.getSheetByName('Raw Rank Data');
+
+  // Create the 'Raw Rank Data' sheet if it doesn't exist
+  if (!rankingSheet) {
+    rankingSheet = ss.insertSheet('Raw Rank Data', ss.getNumSheets());
+    const headers = [
+      'ASIN',
+      'Keyword',
+      'Date',
+      'Organic Rank',
+      'Sponsored Rank',
+      'Overall Rank',
+      'Exact Bid',
+      'Broad Bid',
+      '30-Day Volume'
+    ];
+    rankingSheet.appendRow(headers);
+    
+    // Freeze the top row, make it bold, and set background color
+    rankingSheet.setFrozenRows(1);
+    rankingSheet.getRange('A1:I1').setFontWeight('bold').setBackground('#EFEFEF');
+  }
+
   const existingData = rankingSheet.getDataRange().getValues();
 
   let continueFetching = true;


### PR DESCRIPTION
## Description

This PR makes an improvement to the spreadsheet functionality if a tab doesn't exist. If a specific tab doesn't exist, a new tab is created and the appropriate header is added. This applies to the "Raw Rank Data", "Rank by Day", "Keyword Volume", "Organic Impressions", and "Charts" tabs.

It also removes the `populateRankByDaySheet` function that was no longer used. 